### PR TITLE
Add packages to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,11 @@ setup(
     # Basic package information:
     name = 'django-clear-cache',
     version = '0.2',
-    packages = ('clear_cache',),
+    packages = (
+        'clear_cache',
+        'clear_cache.management',
+        'clear_cache.management.commands'
+    ),
 
     # Packaging options:
     zip_safe = False,


### PR DESCRIPTION
This should install the `management` and `management.commands` packages, which is necessary for Django to find the command. 
